### PR TITLE
Add gallery environment components

### DIFF
--- a/components/environment/artwork-frame.tsx
+++ b/components/environment/artwork-frame.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useTexture } from '@react-three/drei';
+import { Artwork } from '@/lib/types';
+import { DoubleSide } from 'three';
+
+interface ArtworkFrameProps {
+  artwork: Artwork;
+  position: [number, number, number];
+  onClick?: () => void;
+}
+
+export default function ArtworkFrame({ artwork, position, onClick }: ArtworkFrameProps) {
+  const texture = artwork.imageUrl ? useTexture(artwork.imageUrl) : null;
+
+  const width = 2;
+  const height = 1.5;
+  const depth = 0.1;
+  const border = 0.05;
+
+  return (
+    <group position={position} onClick={onClick} name={`artwork-${artwork.id}`}>
+      {/* Frame */}
+      <mesh>
+        <boxGeometry args={[width, height, depth]} />
+        <meshStandardMaterial color={'#555'} metalness={0.2} roughness={0.6} />
+      </mesh>
+
+      {/* Painting */}
+      <mesh position={[0, 0, depth / 2 + 0.001]}>
+        <planeGeometry args={[width - border * 2, height - border * 2]} />
+        {texture ? (
+          <meshStandardMaterial map={texture} side={DoubleSide} />
+        ) : (
+          <meshStandardMaterial color={'white'} side={DoubleSide} />
+        )}
+      </mesh>
+    </group>
+  );
+}
+

--- a/components/environment/gallery-ceiling.tsx
+++ b/components/environment/gallery-ceiling.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { SurfaceConfig } from '@/lib/types';
+import { DoubleSide } from 'three';
+
+interface GalleryCeilingProps {
+  ceilingConfig: SurfaceConfig;
+  dimensions: { width: number; height: number; depth: number };
+}
+
+export default function GalleryCeiling({ ceilingConfig, dimensions }: GalleryCeilingProps) {
+  const material = ceilingConfig.material;
+
+  const matProps = {
+    color: material.color || ceilingConfig.color,
+    metalness: material.metalness ?? 0,
+    roughness: material.roughness ?? 1,
+    emissive: material.emissive ?? '#000000',
+    emissiveIntensity: material.emissiveIntensity ?? 0,
+    transparent: material.transparent ?? false,
+    opacity: material.opacity ?? 1
+  };
+
+  return (
+    <mesh
+      rotation={[Math.PI / 2, 0, 0]}
+      position={[0, dimensions.height, 0]}
+      receiveShadow
+      castShadow
+    >
+      <planeGeometry args={[dimensions.width, dimensions.depth]} />
+      <meshStandardMaterial {...matProps} side={DoubleSide} />
+    </mesh>
+  );
+}
+

--- a/components/environment/gallery-floor.tsx
+++ b/components/environment/gallery-floor.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { SurfaceConfig } from '@/lib/types';
+import { DoubleSide } from 'three';
+
+interface GalleryFloorProps {
+  floorConfig: SurfaceConfig;
+  dimensions: { width: number; height: number; depth: number };
+}
+
+export default function GalleryFloor({ floorConfig, dimensions }: GalleryFloorProps) {
+  const material = floorConfig.material;
+
+  const matProps = {
+    color: material.color || floorConfig.color,
+    metalness: material.metalness ?? 0,
+    roughness: material.roughness ?? 1,
+    emissive: material.emissive ?? '#000000',
+    emissiveIntensity: material.emissiveIntensity ?? 0,
+    transparent: material.transparent ?? false,
+    opacity: material.opacity ?? 1
+  };
+
+  return (
+    <mesh
+      rotation={[-Math.PI / 2, 0, 0]}
+      position={[0, 0, 0]}
+      receiveShadow
+      castShadow
+    >
+      <planeGeometry args={[dimensions.width, dimensions.depth]} />
+      <meshStandardMaterial {...matProps} side={DoubleSide} />
+    </mesh>
+  );
+}
+

--- a/components/environment/gallery-lighting.tsx
+++ b/components/environment/gallery-lighting.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { LightingConfig } from '@/lib/types';
+
+interface GalleryLightingProps {
+  lightingConfigs: LightingConfig[];
+}
+
+export default function GalleryLighting({ lightingConfigs }: GalleryLightingProps) {
+  return (
+    <>
+      {lightingConfigs.map((light) => {
+        if (!light.isEnabled) return null;
+
+        const position = light.position
+          ? [light.position.x, light.position.y, light.position.z]
+          : undefined;
+        const rotation = light.rotation
+          ? [light.rotation.x, light.rotation.y, light.rotation.z]
+          : undefined;
+
+        switch (light.type) {
+          case 'ambient':
+            return (
+              <ambientLight
+                key={light.id}
+                color={light.color}
+                intensity={light.intensity}
+              />
+            );
+          case 'directional':
+            return (
+              <directionalLight
+                key={light.id}
+                position={position}
+                rotation={rotation}
+                color={light.color}
+                intensity={light.intensity}
+                castShadow={light.castShadow}
+                shadow-mapSize-width={light.shadowMapSize}
+                shadow-mapSize-height={light.shadowMapSize}
+              />
+            );
+          case 'point':
+            return (
+              <pointLight
+                key={light.id}
+                position={position}
+                color={light.color}
+                intensity={light.intensity}
+                distance={light.distance}
+                castShadow={light.castShadow}
+              />
+            );
+          case 'spot':
+            return (
+              <spotLight
+                key={light.id}
+                position={position}
+                rotation={rotation}
+                color={light.color}
+                intensity={light.intensity}
+                distance={light.distance}
+                angle={light.angle}
+                penumbra={light.penumbra}
+                castShadow={light.castShadow}
+                shadow-mapSize-width={light.shadowMapSize}
+                shadow-mapSize-height={light.shadowMapSize}
+              />
+            );
+          default:
+            return null;
+        }
+      })}
+    </>
+  );
+}
+

--- a/components/environment/gallery-walls.tsx
+++ b/components/environment/gallery-walls.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { SurfaceConfig } from '@/lib/types';
+import { DoubleSide } from 'three';
+
+interface GalleryWallsProps {
+  wallConfig: SurfaceConfig;
+  dimensions: { width: number; height: number; depth: number };
+}
+
+export default function GalleryWalls({ wallConfig, dimensions }: GalleryWallsProps) {
+  const material = wallConfig.material;
+
+  const matProps = {
+    color: material.color || wallConfig.color,
+    metalness: material.metalness ?? 0,
+    roughness: material.roughness ?? 1,
+    emissive: material.emissive ?? '#000000',
+    emissiveIntensity: material.emissiveIntensity ?? 0,
+    transparent: material.transparent ?? false,
+    opacity: material.opacity ?? 1
+  };
+
+  const { width, height, depth } = dimensions;
+
+  return (
+    <group>
+      {/* Back Wall */}
+      <mesh
+        position={[0, height / 2, -depth / 2]}
+        receiveShadow
+        castShadow
+      >
+        <planeGeometry args={[width, height]} />
+        <meshStandardMaterial {...matProps} side={DoubleSide} />
+      </mesh>
+
+      {/* Left Wall */}
+      <mesh
+        position={[-width / 2, height / 2, 0]}
+        rotation={[0, Math.PI / 2, 0]}
+        receiveShadow
+        castShadow
+      >
+        <planeGeometry args={[depth, height]} />
+        <meshStandardMaterial {...matProps} side={DoubleSide} />
+      </mesh>
+
+      {/* Right Wall */}
+      <mesh
+        position={[width / 2, height / 2, 0]}
+        rotation={[0, -Math.PI / 2, 0]}
+        receiveShadow
+        castShadow
+      >
+        <planeGeometry args={[depth, height]} />
+        <meshStandardMaterial {...matProps} side={DoubleSide} />
+      </mesh>
+    </group>
+  );
+}
+

--- a/components/environment/sculpture-pedestal.tsx
+++ b/components/environment/sculpture-pedestal.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Artwork } from '@/lib/types';
+
+interface SculpturePedestalProps {
+  artwork: Artwork;
+  position: [number, number, number];
+}
+
+export default function SculpturePedestal({ artwork, position }: SculpturePedestalProps) {
+  const width = 1;
+  const depth = 1;
+  const height = 0.8;
+
+  return (
+    <mesh
+      position={[position[0], position[1] + height / 2, position[2]]}
+      receiveShadow
+      castShadow
+      name={`pedestal-${artwork.id}`}
+    >
+      <boxGeometry args={[width, height, depth]} />
+      <meshStandardMaterial color={'#f8f8f8'} metalness={0.1} roughness={0.3} />
+    </mesh>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add 3D environment meshes for gallery walls, floor and ceiling
- implement basic lighting support for scenes
- render simple artwork frames and sculpture pedestals

## Testing
- `npm install` *(fails: ERESOLVE unable to resolve dependency tree)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df29cc45c8321ab9c5c30e772c9a7