### PR TITLE
Fix Prisma output path

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,7 +1,8 @@
 generator client {
     provider = "prisma-client-js"
     binaryTargets = ["native", "linux-musl-arm64-openssl-3.0.x"]
-    output = "/home/ubuntu/moshir-gallery/app/node_modules/.prisma/client"
+    // The output path should be relative to ensure portability across environments
+    output = "./node_modules/.prisma/client"
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- use relative path for Prisma client output
- attempted `npx prisma generate`

## Testing
- `npx prisma generate` *(fails: npm install prisma@6.9.0)*

------
https://chatgpt.com/codex/tasks/task_e_684df96865708321be98721441986eb7