### PR TITLE
Add material editor UI to admin tools

### DIFF
--- a/components/admin/artwork-manager.tsx
+++ b/components/admin/artwork-manager.tsx
@@ -8,6 +8,8 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
+import MaterialEditor from '@/components/admin/material-editor';
+import { DEFAULT_MATERIAL } from '@/lib/types';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { useToast } from '@/hooks/use-toast';
@@ -59,12 +61,14 @@ export default function ArtworkManager({ onStatsUpdate }: ArtworkManagerProps) {
     price: 0,
     imageUrl: '',
     type: 'painting',
+    materialProperties: DEFAULT_MATERIAL,
     position: { x: 0, y: 2, z: 0 },
     rotation: { x: 0, y: 0, z: 0 },
     scale: { x: 1, y: 1, z: 1 }
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { toast } = useToast();
+
 
   useEffect(() => {
     loadArtworks();
@@ -138,6 +142,7 @@ export default function ArtworkManager({ onStatsUpdate }: ArtworkManagerProps) {
       price: artwork.price,
       imageUrl: artwork.imageUrl || '',
       type: artwork.type,
+      materialProperties: artwork.materialProperties || DEFAULT_MATERIAL,
       position: artwork.position || { x: 0, y: 2, z: 0 },
       rotation: artwork.rotation || { x: 0, y: 0, z: 0 },
       scale: artwork.scale || { x: 1, y: 1, z: 1 }
@@ -184,6 +189,7 @@ export default function ArtworkManager({ onStatsUpdate }: ArtworkManagerProps) {
       price: 0,
       imageUrl: '',
       type: 'painting',
+      materialProperties: DEFAULT_MATERIAL,
       position: { x: 0, y: 2, z: 0 },
       rotation: { x: 0, y: 0, z: 0 },
       scale: { x: 1, y: 1, z: 1 }
@@ -314,6 +320,17 @@ export default function ArtworkManager({ onStatsUpdate }: ArtworkManagerProps) {
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                   rows={4}
                   required
+                />
+              </div>
+
+              <div className="border rounded-lg p-4 space-y-4">
+                <h4 className="font-semibold flex items-center gap-2">
+                  <Palette className="h-4 w-4" />
+                  Material Properties
+                </h4>
+                <MaterialEditor
+                  material={formData.materialProperties}
+                  onChange={(mat) => setFormData({ ...formData, materialProperties: mat })}
                 />
               </div>
 

--- a/components/admin/environment-manager.tsx
+++ b/components/admin/environment-manager.tsx
@@ -9,6 +9,7 @@ import { Label } from '@/components/ui/label';
 import { Table, TableBody, TableHead, TableHeader, TableRow, TableCell } from '@/components/ui/table';
 import { useToast } from '@/hooks/use-toast';
 import { Plus, Edit, Trash2, CheckCircle } from 'lucide-react';
+import MaterialEditor from '@/components/admin/material-editor';
 
 interface LightingConfig {
   id: string;
@@ -39,6 +40,9 @@ export default function EnvironmentManager() {
   const [editingEnv, setEditingEnv] = useState<GalleryEnvironment | null>(null);
   const [lightConfigs, setLightConfigs] = useState<LightingConfig[]>([]);
   const [formData, setFormData] = useState({ name: '', width: 20, height: 4, depth: 15 });
+  const [wallMaterial, setWallMaterial] = useState(defaultMaterial);
+  const [floorMaterial, setFloorMaterial] = useState(defaultMaterial);
+  const [ceilingMaterial, setCeilingMaterial] = useState(defaultMaterial);
   const { toast } = useToast();
 
   const defaultMaterial = {
@@ -76,6 +80,9 @@ export default function EnvironmentManager() {
     setEditingEnv(null);
     setFormData({ name: '', width: 20, height: 4, depth: 15 });
     setLightConfigs([]);
+    setWallMaterial(defaultMaterial);
+    setFloorMaterial(defaultMaterial);
+    setCeilingMaterial(defaultMaterial);
     setIsDialogOpen(true);
   };
 
@@ -83,6 +90,9 @@ export default function EnvironmentManager() {
     setEditingEnv(env);
     setFormData({ name: env.name, width: env.dimensions.width, height: env.dimensions.height, depth: env.dimensions.depth });
     setLightConfigs(env.lightingConfigs || []);
+    setWallMaterial(env.wallConfig?.material || { ...defaultMaterial, color: env.wallConfig?.color || '#ffffff' });
+    setFloorMaterial(env.floorConfig?.material || { ...defaultMaterial, color: env.floorConfig?.color || '#ffffff' });
+    setCeilingMaterial(env.ceilingConfig?.material || { ...defaultMaterial, color: env.ceilingConfig?.color || '#ffffff' });
     setIsDialogOpen(true);
   };
 
@@ -91,9 +101,9 @@ export default function EnvironmentManager() {
 
     const payload = {
       name: formData.name,
-      wallConfig: editingEnv?.wallConfig || defaultSurface,
-      floorConfig: editingEnv?.floorConfig || defaultSurface,
-      ceilingConfig: editingEnv?.ceilingConfig || defaultSurface,
+      wallConfig: { color: wallMaterial.color || '#ffffff', material: wallMaterial },
+      floorConfig: { color: floorMaterial.color || '#ffffff', material: floorMaterial },
+      ceilingConfig: { color: ceilingMaterial.color || '#ffffff', material: ceilingMaterial },
       dimensions: { width: formData.width, height: formData.height, depth: formData.depth }
     };
 
@@ -243,6 +253,15 @@ export default function EnvironmentManager() {
                 <Label htmlFor="depth">Depth</Label>
                 <Input type="number" id="depth" value={formData.depth} onChange={(e) => setFormData({ ...formData, depth: Number(e.target.value) })} required />
               </div>
+            </div>
+
+            <div className="space-y-4">
+              <h3 className="font-semibold">Wall Material</h3>
+              <MaterialEditor material={wallMaterial} onChange={setWallMaterial} />
+              <h3 className="font-semibold">Floor Material</h3>
+              <MaterialEditor material={floorMaterial} onChange={setFloorMaterial} />
+              <h3 className="font-semibold">Ceiling Material</h3>
+              <MaterialEditor material={ceilingMaterial} onChange={setCeilingMaterial} />
             </div>
 
             <div className="space-y-4">

--- a/components/admin/material-editor.tsx
+++ b/components/admin/material-editor.tsx
@@ -1,0 +1,71 @@
+import { MaterialProperties } from '@/lib/types';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface MaterialEditorProps {
+  material: MaterialProperties;
+  onChange: (material: MaterialProperties) => void;
+  className?: string;
+}
+
+export default function MaterialEditor({ material, onChange, className }: MaterialEditorProps) {
+  const update = (prop: keyof MaterialProperties, value: any) => {
+    onChange({
+      ...material,
+      [prop]: value,
+    });
+  };
+
+  return (
+    <div className={className ? className : 'grid grid-cols-2 md:grid-cols-4 gap-4'}>
+      <div>
+        <Label htmlFor="mat-color">Color</Label>
+        <Input
+          id="mat-color"
+          type="color"
+          value={material.color}
+          onChange={(e) => update('color', e.target.value)}
+        />
+      </div>
+      <div>
+        <Label htmlFor="mat-metalness">Metalness</Label>
+        <Input
+          id="mat-metalness"
+          type="range"
+          min="0"
+          max="1"
+          step="0.1"
+          value={material.metalness}
+          onChange={(e) => update('metalness', parseFloat(e.target.value))}
+        />
+        <span className="text-xs text-gray-500">{material.metalness}</span>
+      </div>
+      <div>
+        <Label htmlFor="mat-roughness">Roughness</Label>
+        <Input
+          id="mat-roughness"
+          type="range"
+          min="0"
+          max="1"
+          step="0.1"
+          value={material.roughness}
+          onChange={(e) => update('roughness', parseFloat(e.target.value))}
+        />
+        <span className="text-xs text-gray-500">{material.roughness}</span>
+      </div>
+      <div>
+        <Label htmlFor="mat-opacity">Opacity</Label>
+        <Input
+          id="mat-opacity"
+          type="range"
+          min="0"
+          max="1"
+          step="0.1"
+          value={material.opacity}
+          onChange={(e) => update('opacity', parseFloat(e.target.value))}
+        />
+        <span className="text-xs text-gray-500">{material.opacity}</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `MaterialEditor` component for editing basic material properties
- use `MaterialEditor` in environment manager dialog
- allow artworks to specify material properties and edit them

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df97fc85c832183fb851108e00af4