### PR TITLE
Add generic TransformControls

### DIFF
--- a/components/gallery/artwork-transform-controls.tsx
+++ b/components/gallery/artwork-transform-controls.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import { TransformControls } from '@react-three/drei';
+import { Artwork, Transform3D } from '@/lib/types';
+import * as THREE from 'three';
+
+interface ArtworkTransformControlsProps {
+  artwork: Artwork;
+  object: THREE.Object3D | null;
+  mode: 'translate' | 'rotate' | 'scale';
+  enabled: boolean;
+  onTransformChange: (artworkId: string, transform: Transform3D) => void;
+}
+
+export default function ArtworkTransformControls({
+  artwork,
+  object,
+  mode,
+  enabled,
+  onTransformChange
+}: ArtworkTransformControlsProps) {
+  const controlsRef = useRef<any>(null);
+
+  useEffect(() => {
+    if (!controlsRef.current || !object) return;
+
+    const controls = controlsRef.current;
+    controls.attach(object);
+
+    const handleDrag = (event: any) => {
+      if (event.value) return;
+      const obj = controls.object as THREE.Object3D;
+      if (!obj) return;
+      const transform: Transform3D = {
+        position: { x: obj.position.x, y: obj.position.y, z: obj.position.z },
+        rotation: { x: obj.rotation.x, y: obj.rotation.y, z: obj.rotation.z },
+        scale: { x: obj.scale.x, y: obj.scale.y, z: obj.scale.z }
+      };
+      onTransformChange(artwork.id, transform);
+    };
+
+    controls.addEventListener('dragging-changed', handleDrag);
+    return () => {
+      controls.removeEventListener('dragging-changed', handleDrag);
+    };
+  }, [object, artwork.id, onTransformChange]);
+
+  if (!enabled || !object) return null;
+
+  return <TransformControls ref={controlsRef} mode={mode} />;
+}


### PR DESCRIPTION
## Summary
- add new `ArtworkTransformControls` component for applying `TransformControls` to any artwork
- select artwork inside the scene and show transform controls for the selection
- propagate transform updates through `onArtworkTransform`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Type 'number[] | undefined' is not assignable to type 'Vector3 | undefined')*

------
https://chatgpt.com/codex/tasks/task_e_684df9848020832193a12b6a258ddaee