### PR TITLE
Configure Next.js standalone output

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,19 +1,5 @@
-const path = require('path');
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  distDir: process.env.NEXT_DIST_DIR || '.next',
-  output: process.env.NEXT_OUTPUT_MODE,
-  experimental: {
-    outputFileTracingRoot: path.join(__dirname, '../'),
-  },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
-  typescript: {
-    ignoreBuildErrors: false,
-  },
-  images: { unoptimized: true },
-};
-
-module.exports = nextConfig;
+  output: 'standalone',
+}
+module.exports = nextConfig


### PR DESCRIPTION
## Summary
- simplify Next.js configuration and use standalone output

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_e_688794d0d01c8321b1d9e20596e45da0