### PR TITLE
Protect seed route in production

### DIFF
--- a/app/api/seed/route.ts
+++ b/app/api/seed/route.ts
@@ -13,6 +13,9 @@ import {
 export const dynamic = "force-dynamic";
 
 export async function POST() {
+  if (process.env.NODE_ENV === 'production') {
+    return new Response('Forbidden', { status: 403 });
+  }
   try {
     // Create default admin
     await createDefaultAdmin();


### PR DESCRIPTION
## Summary
- deny POST /api/seed access when running in production

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6887963edc308321a3e546d4736f5bf6